### PR TITLE
ported library

### DIFF
--- a/core/src/main/scala/better/files/Dsl.scala
+++ b/core/src/main/scala/better/files/Dsl.scala
@@ -19,7 +19,7 @@ object Dsl {
   def cwd: File =
     pwd
 
-  val `..` : File => File =
+  val `..` : File => File | Null =
     _.parent
 
   val `.` : File => File =

--- a/core/src/main/scala/better/files/FileMonitor.scala
+++ b/core/src/main/scala/better/files/FileMonitor.scala
@@ -48,7 +48,9 @@ abstract class FileMonitor(val root: File, maxDepth: Int) extends File.Monitor {
       if (file.isDirectory) {
         file.walk(depth).filter(f => f.isDirectory && f.exists)
       } else {
-        when(file.exists)(file.parent).iterator // There is no way to watch a regular file; so watch its parent instead
+        when(file.exists)(file.parent)
+          .map(_.nn)
+          .iterator // There is no way to watch a regular file; so watch its parent instead
       }
     try {
       toWatch.foreach(f => Try[Unit](f.register(service)).recover(PartialFunction.fromFunction(onException)).get)

--- a/core/src/main/scala/better/files/Implicits.scala
+++ b/core/src/main/scala/better/files/Implicits.scala
@@ -115,14 +115,17 @@ trait Implicits extends ManagedResource.FlatMap.Implicits with Scanner.Read.Impl
         bufferSize: Int = DefaultBufferSize
       ): ObjectInputStream =
       new ObjectInputStream(if (bufferSize <= 0) in else buffered(bufferSize)) {
-        override protected def resolveClass(objectStreamClass: ObjectStreamClass): Class[_] =
+        override protected def resolveClass(_objectStreamClass: ObjectStreamClass | Null): Class[_] = {
+          val objectStreamClass = _objectStreamClass.nn
           try {
             Class.forName(objectStreamClass.getName, false, classLoader)
           } catch {
             case _: ClassNotFoundException ⇒ super.resolveClass(objectStreamClass)
           }
+        }
 
-        override protected def resolveProxyClass(interfaces: Array[String]): Class[_] = {
+        override protected def resolveProxyClass(_interfaces: Array[String | Null] | Null): Class[_] = {
+          val interfaces = _interfaces.nn
           try {
             java.lang.reflect.Proxy.getProxyClass(
               classLoader,

--- a/core/src/main/scala/better/files/ReaderInputStream.scala
+++ b/core/src/main/scala/better/files/ReaderInputStream.scala
@@ -51,7 +51,8 @@ class ReaderInputStream(reader: Reader, encoder: CharsetEncoder, bufferSize: Int
     encoderOut.flip()
   }
 
-  override def read(b: Array[Byte], off: Int, len: Int) = {
+  override def read(_b: Array[Byte] | Null, off: Int, len: Int) = {
+    val b = _b.nn
     if (len < 0 || off < 0 || (off + len) > b.length)
       throw new IndexOutOfBoundsException("Array Size=" + b.length + ", offset=" + off + ", length=" + len)
     if (len == 0) {

--- a/core/src/main/scala/better/files/Scanner.scala
+++ b/core/src/main/scala/better/files/Scanner.scala
@@ -189,6 +189,6 @@ object StringSplitter {
     * @return
     */
   def regex(pattern: String): StringSplitter = new StringSplitter {
-    override def split(s: String) = s.split(pattern, -1)
+    override def split(s: String) = s.split(pattern, -1).map(_.nn)
   }
 }

--- a/core/src/main/scala/better/files/TeeOutputStream.scala
+++ b/core/src/main/scala/better/files/TeeOutputStream.scala
@@ -8,11 +8,11 @@ import java.io.OutputStream
   * @param outs
   */
 class TeeOutputStream(outs: OutputStream*) extends OutputStream {
-  override def write(b: Int)                             = tryAll(outs)(_.write(b))
-  override def flush()                                   = tryAll(outs)(_.flush())
-  override def write(b: Array[Byte])                     = tryAll(outs)(_.write(b))
-  override def write(b: Array[Byte], off: Int, len: Int) = tryAll(outs)(_.write(b, off, len))
-  override def close()                                   = tryAll(outs)(_.close())
+  override def write(b: Int)                                    = tryAll(outs)(_.write(b))
+  override def flush()                                          = tryAll(outs)(_.flush())
+  override def write(b: Array[Byte] | Null)                     = tryAll(outs)(_.write(b))
+  override def write(b: Array[Byte] | Null, off: Int, len: Int) = tryAll(outs)(_.write(b, off, len))
+  override def close()                                          = tryAll(outs)(_.close())
 }
 
 /**

--- a/core/src/main/scala/better/files/WriterOutputStream.scala
+++ b/core/src/main/scala/better/files/WriterOutputStream.scala
@@ -41,7 +41,7 @@ class WriterOutputStream(writer: Writer, decoder: CharsetDecoder, bufferSize: In
       flushImmediately = flushImmediately
     )
 
-  override def write(b: Array[Byte], off: Int, len: Int) = {
+  override def write(b: Array[Byte] | Null, off: Int, len: Int) = {
     @tailrec def loop(off: Int, len: Int): Unit = if (len > 0) {
       val c = decoderIn.remaining min len
       decoderIn.put(b, off, c)


### PR DESCRIPTION
LOC changed: 27

**Nullable variable** | 3
Variables that really can be null and should therefore have a `| Null` type.

**Nullable parameter** | 1
Parameter that can be null and should therefore have a `| Null` type.

 **Nullable variable is used** | 5
Requires `.nn` to remove nullness.

**Pass array into java method** | 2
Pass `Array[T]` as argument to java method that requires an array. Java arrays have type `Array[T | Null]`.

**Overridden java method arguments are nullable** | 10
A Scala method overrides some Java method. We need to add `|Null` to the method's parameter types to make the override still work.

**Java method returns array** | 2
Java method returns array of type `Array[Null | T]`. We need to map it to `Array[T]`.

**Overridden java arguments are never null** | 6
Argument should never be null, immediately remove nullness of parameter.

**Overridden java array field**
A Scala field overrides some Java array field. We need to use `Array[T | Null]` instead of `Array[T]` for the overriding to work.